### PR TITLE
Adicionando o Coveralls ao repositório

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,14 @@
+sudo: required
+
+language: ruby
+rvm:
+  - 2.3.1
+
 before_script:
   - psql -c 'create database "inclucare-api_test";' -U postgres
 
-language: ruby
+script:
+  - bundle exec rake
+
+after_success:
+- CI=true TRAVIS=true coveralls --verboose

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,9 @@ gem 'devise_token_auth'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
+  gem 'coveralls', require: false
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
+  gem 'simplecov'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,6 +50,12 @@ GEM
     case_transform (0.2)
       activesupport
     concurrent-ruby (1.0.5)
+    coveralls (0.7.1)
+      multi_json (~> 1.3)
+      rest-client
+      simplecov (>= 0.7)
+      term-ansicolor
+      thor
     crass (1.0.4)
     devise (4.4.3)
       bcrypt (~> 3.0)
@@ -60,13 +66,19 @@ GEM
     devise_token_auth (0.1.43)
       devise (> 3.5.2, < 4.5)
       rails (< 6)
+    docile (1.3.0)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     erubi (1.7.1)
     ffi (1.9.23)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.0.0)
       concurrent-ruby (~> 1.0)
+    json (2.1.0)
     jsonapi-renderer (0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -78,9 +90,14 @@ GEM
     mail (2.7.0)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
     mini_mime (1.0.0)
     mini_portile2 (2.3.0)
     minitest (5.11.3)
+    multi_json (1.13.1)
+    netrc (0.11.0)
     nio4r (2.3.0)
     nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
@@ -124,7 +141,16 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     ruby_dep (1.5.0)
+    simplecov (0.16.1)
+      docile (~> 1.1)
+      json (>= 1.8, < 3)
+      simplecov-html (~> 0.10.0)
+    simplecov-html (0.10.2)
     spring (2.0.2)
       activesupport (>= 4.2)
     spring-watcher-listen (2.0.1)
@@ -137,10 +163,16 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    term-ansicolor (1.6.0)
+      tins (~> 1.0)
     thor (0.20.0)
     thread_safe (0.3.6)
+    tins (1.16.3)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     warden (1.2.7)
       rack (>= 1.0)
     websocket-driver (0.6.5)
@@ -153,6 +185,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers (~> 0.10.0)
   byebug
+  coveralls
   devise_token_auth
   listen (>= 3.0.5, < 3.2)
   omniauth
@@ -160,6 +193,7 @@ DEPENDENCIES
   puma (~> 3.7)
   rack-cors
   rails (~> 5.1.6)
+  simplecov
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 <p align="center">
   <a href="https://codeclimate.com/github/fga-gpp-mds/22018.1-IncluCare_API"><img src="https://codeclimate.com/github/fga-gpp-mds/2018.1-IncluCare_API/badges/gpa.svg"></a>
 <a href="https://travis-ci.org/fga-gpp-mds/2018.1-IncluCare_API/"><img src="https://api.travis-ci.org/fga-gpp-mds/2018.1-IncluCare_API.svg?branch=master"></a>
+  <a href='https://coveralls.io/github/fga-gpp-mds/2018.1-IncluCare_API?branch=feature%2Fcoveralls'><img src='https://coveralls.io/repos/github/fga-gpp-mds/2018.1-IncluCare_API/badge.svg?branch=feature%2Fcoveralls' alt='Coverage Status' /></a>
+
 </p>
   
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,9 @@ ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 
+require 'coveralls'
+Coveralls.wear!
+
 class ActiveSupport::TestCase
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
- Adicionando: 
- as configurações de integração do Travis CI com o coveralls
- as configurações do Coveralls
- indicador de cobertura de testes no README.